### PR TITLE
docs: add MonitorFlare (enhanced fork) to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Uptime Monitor 是一个基于 Cloudflare Workers、Pages 和 D1 的轻量级网
 
 演示密码仅用于公开 Demo，请不要作为自己的生产环境管理口令。
 
+## 相关项目
+
+- [MonitorFlare](https://github.com/xusteve/MonitorFlare)：基于本项目的增强分支，利用 Cloudflare Workers + D1 + Pages 免费层实现零成本监控与公开状态页，支持多语言与多种通知渠道。演示：[https://monitorflare.csr.plus](https://monitorflare.csr.plus)
+
 ## 界面预览
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Uptime Monitor 是一个基于 Cloudflare Workers、Pages 和 D1 的轻量级网
 
 ## 相关项目
 
-- [MonitorFlare](https://github.com/xusteve/MonitorFlare)：基于本项目的增强分支，利用 Cloudflare Workers + D1 + Pages 免费层实现零成本监控与公开状态页，支持多语言与多种通知渠道。演示：[https://monitorflare.csr.plus](https://monitorflare.csr.plus)
+- [MonitorFlare](https://github.com/xusteve/MonitorFlare)：基于本项目的增强分支，利用 Cloudflare Workers + D1 + Pages 免费层实现零成本监控与公开状态页，支持多语言与多种通知渠道。项目：[https://monitorflare.csr.plus](https://monitorflare.csr.plus)，在线演示：[https://uptime.csr.plus](https://uptime.csr.plus)
 
 ## 界面预览
 


### PR DESCRIPTION
Hi! [MonitorFlare](https://github.com/xusteve/MonitorFlare) is an enhanced fork of this project (MIT), running entirely on the Cloudflare free tier (Workers + D1 + Pages) with multi-language support and more notification channels.

I added it to the README's related projects section for better discoverability. Happy to adjust wording or placement if you prefer.

Project site: https://monitorflare.csr.plus
Live demo: https://uptime.csr.plus