### PR TITLE
fix(worker): 修复 D1 初始化脚本中重复 SQL 导致的语法错误

### DIFF
--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -29,37 +29,6 @@ CREATE TABLE monitors (
   paused INTEGER DEFAULT 0,
   check_ssl INTEGER DEFAULT 1,             -- 是否检测 SSL 证书到期 (1=开, 0=关)
   check_domain INTEGER DEFAULT 1,          -- 是否检测域名到期 (1=开, 0=关)
--- ============================================================
--- Uptime Monitor Schema
--- 初始化（全新数据库使用此完整 SQL）
--- 增量迁移请使用文件末尾的 ALTER TABLE 语句
--- ============================================================
-
-DROP TABLE IF EXISTS logs;
-DROP TABLE IF EXISTS monitors;
-DROP TABLE IF EXISTS incidents;
-DROP TABLE IF EXISTS settings;
-
-CREATE TABLE monitors (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  name TEXT NOT NULL,
-  url TEXT NOT NULL,
-  method TEXT DEFAULT 'GET',
-  request_headers TEXT,                    -- JSON 格式自定义请求头
-  request_body TEXT,                       -- POST 请求体
-  interval INTEGER DEFAULT 300,
-  status TEXT DEFAULT 'UP',
-  retry_count INTEGER DEFAULT 0,
-  last_check DATETIME,
-  keyword TEXT,
-  user_agent TEXT,
-  tags TEXT,                               -- 逗号分隔标签，如 "prod,web"
-  domain_expiry TEXT,
-  cert_expiry TEXT,
-  check_info_status TEXT,
-  paused INTEGER DEFAULT 0,
-  check_ssl INTEGER DEFAULT 1,             -- 是否检测 SSL 证书到期 (1=开, 0=关)
-  check_domain INTEGER DEFAULT 1,          -- 是否检测域名到期 (1=开, 0=关)
   alert_silence_uptime INTEGER DEFAULT 24,  -- 可用性告警静默窗口（小时）
   alert_silence_ssl INTEGER DEFAULT 24,     -- SSL 证书告警静默窗口（小时）
   alert_silence_domain INTEGER DEFAULT 24,  -- 域名到期告警静默窗口（小时）


### PR DESCRIPTION
执行 `npx wrangler d1 execute uptime-db --remote --file=worker/schema.sql` 初始化 D1 时，导入失败并报错 `near "DROP": syntax error at offset 1047: SQLITE_ERROR`。

原因是脚本开头包含一段重复且未闭合的 `CREATE TABLE monitors (`，后面直接接上另一段初始化头部和 `DROP TABLE` 语句，导致 SQL 解析失败。

本次删除这 31 行重复内容，保留完整的表结构、索引与默认配置，使初始化脚本能够正常执行。

验证结果：

- 原始脚本在本地 SQLite 中可复现 `near "DROP": syntax error`。
- 修正版在本地 SQLite 中成功创建 6 张业务表、写入 6 项默认配置，并通过监控记录插入与默认值检查。
- 使用者已确认修复后远程 D1 初始化成功。
- `git diff --check` 通过。